### PR TITLE
subclass requests.Session for openshift API classes

### DIFF
--- a/openshift.py
+++ b/openshift.py
@@ -46,26 +46,22 @@ class openshift(requests.Session):
 
         return super().request(method, url, **kwargs)
 
-
-class openshift_3_x(openshift):
-
     def project_exists(self, project_name):
-        url = f"/oapi/v1/projects/{project_name}"
+        url = f"{self.project_api_endpoint}/{project_name}"
         r = self.get(url)
         return r.status_code == 200 or r.status_code == 201
 
     def delete_project(self, project_name):
         # check project_name
-        url = f"/oapi/v1/projects/{project_name}"
+        url = f"{self.project_api_endpoint}/{project_name}"
         r = self.delete(url)
         return r
 
     def create_project(self, project_id, project_name, user_name):
         # check project_name
-        url = "/oapi/v1/projects"
         payload = {
             "kind": "Project",
-            "apiVersion": "user.openshift.io/v1",
+            "apiVersion": self.project_api_version,
             "metadata": {
                 "name": project_id,
                 "annotations": {
@@ -74,41 +70,16 @@ class openshift_3_x(openshift):
                 },
             },
         }
-        return self.post(url, data=json.dumps(payload))
+        return self.post(self.project_api_endpoint, data=json.dumps(payload))
 
-    # member functions for users
 
-    # member functions to associate roles for users on projects
+class openshift_3_x(openshift):
+
+    project_api_endpoint = "/oapi/v1/projects"
+    project_api_version = "v1"
 
 
 class openshift_4_x(openshift):
 
-    # member functions for projects
-    def project_exists(self, project_name):
-        url = f"/apis/project.openshift.io/v1/projects/{project_name}"
-        r = self.get(url)
-        return r.status_code == 200 or r.status_code == 201
-
-    def delete_project(self, project_name):
-        # check project_name
-        url = f"/apis/project.openshift.io/v1/projects/{project_name}"
-        return self.delete(url)
-
-    def create_project(self, project_id, project_name, user_name):
-        url = "/apis/project.openshift.io/v1/projects/"
-        payload = {
-            "kind": "Project",
-            "apiVersion": "project.openshift.io/v1",
-            "metadata": {
-                "name": project_id,
-                "annotations": {
-                    "openshift.io/display-name": project_name,
-                    "openshift.io/requester": user_name,
-                },
-            },
-        }
-        return self.post(url, data=json.dumps(payload))
-
-    # member functions for users
-
-    # member functions to associate roles for users on projects
+    project_api_endpoint = "/apis/project.openshift.io/v1/projects"
+    project_api_version = "project.openshift.io/v1"

--- a/openshift.py
+++ b/openshift.py
@@ -1,139 +1,114 @@
-import kubernetes
-import pprint
-import logging
-import requests
 import json
 import re
-from flask import Flask, redirect, url_for, request, Response
+import requests
 
-import sys
 
-#application = Flask(__name__)
+class openshift(requests.Session):
+    baseurl = None
 
-class openshift:
-    headers = None
-    verify = False
-    url = None
-        
-    def __init__(self,url,token,logger):
+    def __init__(self, url, token, verify, logger):
+        super().__init__()
+
+        self.set_verify(verify)
         self.set_token(token)
-        self.set_url(url)
-        self.logger=logger
+        self.set_baseurl(url)
+        self.set_logger(logger)
+        self.set_headers()
+
+    def set_verify(self, verify):
+        self.verify = verify
+
+    def set_headers(self):
+        self.headers.update({
+            'Authorization': f'bearer {self.token}',
+            'Content-type': 'application/json',
+            'Accept': 'application/json'
+        })
+
+    def set_logger(self, logger):
+        self.logger = logger
 
     def set_token(self, token):
-        self.headers = {
-            "Authorization": "Bearer " + token,
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-        }
-    def set_url(self, url):
-        self.url = url
+        self.token = token
 
-    def get_url(self):
-        return self.url
-    
-    def cnvt_project_name(project_name):
+    def set_baseurl(self, url):
+        self.baseurl = url
+
+    def cnvt_project_name(self, project_name):
         suggested_project_name = re.sub("^[^A-Za-z0-9]+", "", project_name)
         suggested_project_name = re.sub("[^A-Za-z0-9]+$", "", suggested_project_name)
-        suggested_project_name = re.sub("[^A-Za-z0-9\-]+", "-", suggested_project_name)
+        suggested_project_name = re.sub("[^A-Za-z0-9-]+", "-", suggested_project_name)
         return suggested_project_name
-    
-    def get_request(self, url, debug=False):
-        r = requests.get(url, headers=self.headers, verify=self.verify)
-        #        if debug == True:
-        self.logger.info("url: " + url)
-        self.logger.info("r: " + str(r.status_code))
-        self.logger.info("r: " + r.text)
-        return r
 
-    def del_request(self, url, debug=False):
-        r = requests.delete(url, headers=self.headers, verify=self.verify)
-        if debug == True:
-            self.logger.info("url: " + url)
-            self.logger.info("r: " + str(r.status_code))
-            self.logger.info("r: " + r.text)
-        return r
+    def request(self, method, url, **kwargs):
+        if '://' not in url:
+            url = f'{self.baseurl}{url}'
 
-    def post_request(self, url, payload, debug=False):
-        r = requests.post(url, headers=self.headers, data=json.dumps(payload), verify=False)
-        if debug==True:
-            self.logger.info("url: " + url)
-            self.logger.info("payload: " + json.dumps(payload))
-            self.logger.info("r: " + str(r.status_code))
-            self.logger.info("r: " + r.text)
-        return r
+        return super().request(method, url, **kwargs)
+
 
 class openshift_3_x(openshift):
 
-    # member functions for projects
     def project_exists(self, project_name):
-        url = "https://" + self.get_url() + "/oapi/v1/projects/" + project_name
-        r = self.get_request(url, True)
-        if r.status_code == 200 or r.status_code == 201:
-            return True
-        return False
+        url = f"/oapi/v1/projects/{project_name}"
+        r = self.get(url)
+        return r.status_code == 200 or r.status_code == 201
 
     def delete_project(self, project_name):
         # check project_name
-        url = "https://" + self.get_url() + "/oapi/v1/projects/" + project_name
-        r = self.del_request(url, True)
+        url = f"/oapi/v1/projects/{project_name}"
+        r = self.delete(url)
         return r
 
-    def create_project(self, project_name, user_name):
+    def create_project(self, project_id, project_name, user_name):
         # check project_name
-        url = "https://" + self.get_url() + "/oapi/v1/projects"
+        url = "/oapi/v1/projects"
         payload = {
             "kind": "Project",
-            "apiVersion": "v1",
+            "apiVersion": "user.openshift.io/v1",
             "metadata": {
-                "name": project_uuid,
+                "name": project_id,
                 "annotations": {
                     "openshift.io/display-name": project_name,
                     "openshift.io/requester": user_name,
                 },
             },
         }
-        r = self.post_request(url, json.dumps(payload))
-        return r
+        return self.post(url, data=json.dumps(payload))
 
     # member functions for users
 
     # member functions to associate roles for users on projects
+
 
 class openshift_4_x(openshift):
 
     # member functions for projects
     def project_exists(self, project_name):
-        url = "https://" + self.get_url() + "/apis/project.openshift.io/v1/projects/" + project_name
-        r = self.get_request(url, True)
-        if r.status_code == 200 or r.status_code == 201:
-            return True
-        return False
+        url = f"/apis/project.openshift.io/v1/projects/{project_name}"
+        r = self.get(url)
+        return r.status_code == 200 or r.status_code == 201
 
     def delete_project(self, project_name):
         # check project_name
-        url = "https://" + self.get_url() + "/apis/project.openshift.io/v1/projects/" + project_name
-        r = self.del_request(url, True)
-        return r
+        url = f"/apis/project.openshift.io/v1/projects/{project_name}"
+        return self.delete(url)
 
-    def create_project(self, short_name, project_name, user_name):
-        # check project_name
-        url = "https://" + self.get_url() + "/apis/project.openshift.io/v1/projects/"
+    def create_project(self, project_id, project_name, user_name):
+        url = "/apis/project.openshift.io/v1/projects/"
         payload = {
             "kind": "Project",
-            "apiVersion": "v1",
+            "apiVersion": "project.openshift.io/v1",
             "metadata": {
-                "name": short_name,
+                "name": project_id,
                 "annotations": {
                     "openshift.io/display-name": project_name,
                     "openshift.io/requester": user_name,
                 },
             },
         }
-        r = self.post_request(url, json.dumps(payload), True)
-        return r
+        return self.post(url, data=json.dumps(payload))
 
     # member functions for users
 
     # member functions to associate roles for users on projects
-   

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-setuptools>=18.5
+flask
 gunicorn
-Flask
 kubernetes
 openshift
+flask_httpauth


### PR DESCRIPTION
This applies the technique suggested in larsks/openshift-acct-mgt@1297418 to the design of the openshift api classes in `openshift.py`.

With the changes in this commit, it's possible to create/delete/check openshift projects. There is a running instance available at https://acct-mgt-lars-acct-mgt.apps.cnv.massopen.cloud. Using that endpoint, we see the following behavior:

```
$ ENDPOINT=https://acct-mgt-lars-acct-mgt.apps.cnv.massopen.cloud
$ curl -u admin:$PASSWORD $ENDPOINT/projects/another-lars-test
{"msg": "project does not exist (another-lars-test)"}
$ curl -u admin:$PASSWORD $ENDPOINT/projects/another-lars-test -X PUT
{"msg": "project created (another-lars-test)"}
$ curl -u admin:$PASSWORD $ENDPOINT/projects/another-lars-test
{"msg": "project exists (another-lars-test)"}
$ curl -u admin:$PASSWORD $ENDPOINT/projects/another-lars-test -X DELETE
{"msg": "project deleted (another-lars-test)"}
$ curl -u admin:$PASSWORD $ENDPOINT/projects/another-lars-test
{"msg": "project exists (another-lars-test)"}
```

Note that authentication is enabled on these endpoints, and that the credentials are stored as per larsks/openshift-acct-mgt@60bcc1a. The Dockerfile was modified as in larsks/openshift-acct-mgt@382a3afbefb36ed25fd06662d911d239d5b0f5d4. The service was deployed using https://github.com/larsks/openshift-acct-mgt-deploy.
